### PR TITLE
Add support for WordPress Multisite Installations

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -17,7 +17,7 @@ class Bugsnag_Wordpress
 
     private static $NOTIFIER = array(
         'name' => 'Bugsnag Wordpress (Official)',
-        'version' => '1.1.2',
+        'version' => '1.2.1',
         'url' => 'https://bugsnag.com/notifiers/wordpress'
     );
 

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -3,7 +3,7 @@
 Plugin Name: Bugsnag Error Monitoring
 Plugin URI: https://bugsnag.com
 Description: Bugsnag monitors for errors and crashes on your wordpress site, sends them to your bugsnag.com dashboard, and notifies you by email of each error.
-Version: 1.1.2
+Version: 1.2.1
 Author: Bugsnag Inc.
 Author URI: https://bugsnag.com
 License: GPLv2 or later
@@ -25,17 +25,23 @@ class Bugsnag_Wordpress
     private $apiKey;
     private $notifySeverities;
     private $filterFields;
+    private $pluginBase;
 
     public function __construct()
     {
         // Activate bugsnag error monitoring as soon as possible
         $this->activateBugsnag();
 
+        $this->pluginBase = 'bugsnag/bugsnag.php';
+
         // Run init actions (loading wp user)
         add_action('init', array($this, 'initActions'));
 
         // Load admin actions (admin links and pages)
         add_action('admin_menu', array($this, 'adminMenuActions'));
+
+        // Load network admin menu if using multisite
+        add_action('network_admin_menu', array($this, 'networkAdminMenuActions'));
 
         add_action('wp_ajax_test_bugsnag', array($this, 'testBugsnag'));
     }
@@ -53,9 +59,17 @@ class Bugsnag_Wordpress
         }
 
         // Load bugsnag settings
-        $this->apiKey = get_option('bugsnag_api_key');
-        $this->notifySeverities = get_option('bugsnag_notify_severities');
-        $this->filterFields = get_option('bugsnag_filterfields');
+        if ( ! get_site_option('bugsnag_network')) {
+            // Regular
+            $this->apiKey           = get_option( 'bugsnag_api_key' );
+            $this->notifySeverities = get_option( 'bugsnag_notify_severities' );
+            $this->filterFields     = get_option( 'bugsnag_filterfields' );
+        } else {
+            // Multisite
+            $this->apiKey           = get_site_option( 'bugsnag_api_key' );
+            $this->notifySeverities = get_site_option( 'bugsnag_notify_severities' );
+            $this->filterFields     = get_site_option( 'bugsnag_filterfields' );
+        }
 
         $this->constructBugsnag();
     }
@@ -133,11 +147,37 @@ class Bugsnag_Wordpress
 
     public function adminMenuActions()
     {
-        // Add the "settings" link to the Bugsnag row of plugins.php
-        add_filter('plugin_action_links', array($this, 'pluginActionLinksFilter'), 10, 2);
+        if ( ! function_exists( 'is_plugin_active_for_network' ) || ! is_plugin_active_for_network($this->pluginBase)) {
+            // Add the "settings" link to the Bugsnag row of plugins.php
+            add_filter('plugin_action_links', array($this, 'pluginActionLinksFilter'), 10, 2);
 
-        // Create the settings page
-        add_options_page('Bugsnag Settings', 'Bugsnag', 'manage_options', 'bugsnag', array($this, 'renderSettings'));
+            // Create the settings page
+            add_options_page('Bugsnag Settings', 'Bugsnag', 'manage_options', 'bugsnag', array($this, 'renderSettings'));
+        }
+    }
+
+    public function networkAdminMenuActions()
+    {
+        if (function_exists('is_plugin_active_for_network') && is_plugin_active_for_network($this->pluginBase)) {
+            // Create the network settings page
+            add_submenu_page('settings.php', 'Bugsnag Settings', 'Bugsnag', 'manage_network_options', 'bugsnag', array($this, 'renderSettings'));
+        }
+    }
+
+    private function updateNetworkSettings( $settings )
+    {
+        // Update options
+        update_site_option('bugsnag_api_key', isset($_POST['bugsnag_api_key']) ? $_POST['bugsnag_api_key'] : '');
+        update_site_option('bugsnag_notify_severities', isset($_POST['bugsnag_notify_severities']) ? $_POST['bugsnag_notify_severities'] : '');
+        update_site_option('bugsnag_filterfields', isset($_POST['bugsnag_filterfields']) ? $_POST['bugsnag_filterfields'] : '');
+        update_site_option('bugsnag_network', true);
+
+        // Update variables
+        $this->apiKey           = get_site_option( 'bugsnag_api_key' );
+        $this->notifySeverities = get_site_option( 'bugsnag_notify_severities' );
+        $this->filterFields     = get_site_option( 'bugsnag_filterfields' );
+
+        echo '<div class="updated"><p>Settings saved.</p></div>';
     }
 
 
@@ -170,6 +210,10 @@ class Bugsnag_Wordpress
     // Renderers
     public function renderSettings()
     {
+        if ( ! empty($_POST[ 'action' ]) && $_POST[ 'action' ] == 'update') {
+            $this->updateNetworkSettings( $_POST );
+        }
+
         include $this->relativePath('views/settings.php');
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
 Tested up to: 3.8
-Stable tag: 1.1.2
+Stable tag: 1.2.1
 License: GPLv2 or later
 
 Bugsnag is a WordPress plugin that automatically detects errors & crashes on your WordPress site, and notifies you by email, chat or issues system
@@ -37,6 +37,9 @@ To manually install Bugsnag:
 
 
 == Changelog ==
+
+= 1.2.1 =
+* Add support for WordPress Multisite installations.
 
 = 1.2.0 =
 * Update bugsnag-php to allow cURL or fopen.

--- a/views/settings.php
+++ b/views/settings.php
@@ -8,7 +8,11 @@
     Errors are sent to your <a href="https://bugsnag.com">Bugsnag Dashboard</a> for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
   </p>
 
-  <form method="post" action="options.php"> 
+  <?php if (function_exists('is_plugin_active_for_network') && is_plugin_active_for_network($this->pluginBase)) { ?>
+  <form method='post'>
+  <?php } else { ?>
+  <form method="post" action="options.php">
+  <?php } ?>
     <?php if(empty($this->apiKey)) { ?>
 
     <!-- API Key Prompt -->
@@ -38,7 +42,7 @@
           <label for="bugsnag_api_key">Bugsnag API Key</label>
         </th>
         <td>
-          <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" value="<?php echo get_option('bugsnag_api_key'); ?>" class="regular-text code" /><br>
+          <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" value="<?php echo $this->apiKey ?>" class="regular-text code" /><br>
 
           <p class="description">
             You can find your API Key on your <a href="https://bugsnag.com">Bugsnag Dashboard</a>.
@@ -66,7 +70,7 @@
           <label for="bugsnag_filterfields">Bugsnag Field Filter</label>
         </th>
         <td>
-          <textarea id="bugsnag_filterfields" name="bugsnag_filterfields" class="regular-text filterfields"  style="width: 355px; height: 150px;"><?php echo get_option('bugsnag_filterfields'); ?></textarea>
+          <textarea id="bugsnag_filterfields" name="bugsnag_filterfields" class="regular-text filterfields"  style="width: 355px; height: 150px;"><?php echo $this->filterFields; ?></textarea>
           <p class="description" style="max-width: 400px">
             The information to remove from Bugsnag reports, one per line. Use this if you want to ensure you don't send sensitive data such as passwords, and credit card numbers to our servers.
 


### PR DESCRIPTION
By default, Bugsnag requires a separate API key configuration for each
site in a multisite network. For most networks, this is not ideal. All
sites in the network should report to a single Bugsnag dashboard. If
Bugsnag is Network Activated in a Multisite installation, it will now
place the options page in the Network admin panel and only require one
API key (and other settings) for the whole network. If the plugin is
enabled on a per-site basis, it works the same as before, where each
site can have its own settings.