### PR TITLE
feat(loader) allow people to leverage the plugin even if they have cu…

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -53,7 +53,7 @@ class Bugsnag_Wordpress
             require_once $this->relativePath(self::$COMPOSER_AUTOLOADER);
         } elseif (file_exists($this->relativePath(self::$PACKAGED_AUTOLOADER))) {
             require_once $this->relativePath(self::$PACKAGED_AUTOLOADER);
-        } else {
+        } elseif (!class_exists('Bugsnag_Client')){
             error_log("Bugsnag Error: Couldn't activate Bugsnag Error Monitoring due to missing Bugsnag library!");
             return;
         }


### PR DESCRIPTION
We should be able to allow Custom Wordpress developers who have used composer to load the Bugsnag_Client leverage the wordpress plugin. Especially now that we have the Fluent interface.