### PR TITLE
Added post-construction hook

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -91,6 +91,8 @@ class Bugsnag_Wordpress
                 set_error_handler(array($this->client, "errorHandler"));
                 set_exception_handler(array($this->client, "exceptionHandler"));
             }
+            
+            do_action('bugsnag_constructed', $this);
         }
 
     }


### PR DESCRIPTION
I added the `bugsnag_constructed` hook because custom notifiers do not work in Bugsnag tests due to the way `testBugsnag()` constructs and fires a notification directly instead of using `$bugsnagWordpress`.

Example usage:

```

add_action('bugsnag_constructed', function($bs) {
  $bs->setBeforeNotifyFunction(function ($error) {
      $id = get_current_user_id();
      if(!$id) return;
      $user_info = get_userdata($id);
      $error->setUser([
        'id' => $id,
        'username' => $user_info->user_login,
        'email' => $user_info->user_email,
        'first_name'=>$user_info->user_firstname,
        'last_name'=>$user_info->user_lastname,
      ]);
  });
});
```