### PR TITLE
Added ability to define API Key as Constant

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -311,4 +311,11 @@ class Bugsnag_Wordpress
     }
 }
 
+// Add ability to define Bugsnag API Key as constant in wp-config.php
+function bugsnag_define_api_key() {
+  return defined('BUGSNAG_API_KEY') ? BUGSNAG_API_KEY : false;
+}
+add_filter('pre_option_bugsnag_api_key', 'bugsnag_define_api_key');
+add_filter('pre_site_option_bugsnag_api_key', 'bugsnag_define_api_key');
+
 $bugsnagWordpress = new Bugsnag_Wordpress();


### PR DESCRIPTION
Resolves https://github.com/bugsnag/bugsnag-wordpress/issues/18

Example usage (in wp-config.php)
```php
if(WP_ENV !== 'development') {
  // Only log Bugsnag errors on Staging/Production
  define('BUGSNAG_API_KEY', '(OUR_API_KEY)');
}
```