### PR TITLE
Settings Page: Remove deprecated screen_icon

### DIFF
--- a/views/settings.php
+++ b/views/settings.php
@@ -1,5 +1,4 @@
 <div class="wrap">
-  <?php screen_icon(); ?>
   <h2>Bugsnag Settings</h2>
   <p>
     Bugsnag automatically detects errors &amp; crashes on your WordPress site, plugins &amp; themes.


### PR DESCRIPTION
Removes the screen_icon function from the settings page (as it's a deprecated function anyways).