### PR TITLE
Remove action in wp-admin settings form

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -311,4 +311,5 @@ class Bugsnag_Wordpress
     }
 }
 
+global $bugsnagWordpress; // make variable reachable when plugin is used as mu-plugin
 $bugsnagWordpress = new Bugsnag_Wordpress();

--- a/views/settings.php
+++ b/views/settings.php
@@ -10,7 +10,7 @@
   <?php if (function_exists('is_plugin_active_for_network') && is_plugin_active_for_network($this->pluginBase)) { ?>
   <form method='post'>
   <?php } else { ?>
-  <form method="post" action="options.php">
+  <form method="post">
   <?php } ?>
     <?php if(empty($this->apiKey)) { ?>
 


### PR DESCRIPTION
Issue: notices are shown when using action (see https://wordpress.stackexchange.com/a/289620/144404)