### PR TITLE
feat: add Wordpress runtime version reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+Changelog
+=========
+
+## TBD
+
+* Add WordPress version string to report and session payloads (device.runtimeVersions)
+  [#39](https://github.com/bugsnag/bugsnag-wordpress/pull/39)

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -79,6 +79,8 @@ class Bugsnag_Wordpress
                          ->setErrorReportingLevel($this->errorReportingLevel())
                          ->setFilters($this->filterFields());
 
+            $this->client->mergeDeviceData(['runtimeVersions' => ['wordpress' => get_bloginfo('version')]]);
+
             $this->client->setNotifier(self::$NOTIFIER);
 
             // If handlers are not set, errors are still going to be reported

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bugsnag/bugsnag-wordpress",
     "type": "wordpress-plugin",
     "require": {
-        "bugsnag/bugsnag": "^2.2",
+        "bugsnag/bugsnag": "^2.10",
         "composer/installers": "^1.0"
     },
     "license": "MIT",

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   db:
-    image: mysql
+    image: mysql:5.7
     environment:
       - MYSQL_DATABASE=wordpress
       - MYSQL_USER=wp_admin

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
-Tested up to: 4.9.7
+Tested up to: 5.2.1
 Stable tag: 1.3.1
 License: GPLv2 or later
 


### PR DESCRIPTION
Uses new hook in Diagnostics to append the Wordpress application version to device data to
make it reportable.

## Goal

Augments reporting with the version of Wordpress in use when an event occurred in case of issues in a specific version of the framework.

## Design

Added data to device.runtimeVersions.wordpress as per other notifiers.

## Changeset

### Changed

* bugsnag.constructBugsnag - appends the runtime version information to the device data through the Bugsnag client

## Tests

* No unit tests present in repo - checked the data was present after running the example Wordpress project (requires the feature branch of bugsnag-php **v2**)

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
