### PR TITLE
Move exception handler to init action

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -83,16 +83,6 @@ class Bugsnag_Wordpress
 
             $this->client->setNotifier(self::$NOTIFIER);
 
-            // If handlers are not set, errors are still going to be reported
-            // to bugsnag, difference is execution will not stop.
-            //
-            // Can be useful to see inline errors and traces with xdebug too.
-            $set_error_and_exception_handlers = apply_filters('bugsnag_set_error_and_exception_handlers', true);
-            if ($set_error_and_exception_handlers === true) {
-                // Hook up automatic error handling
-                set_error_handler(array($this->client, "errorHandler"));
-                set_exception_handler(array($this->client, "exceptionHandler"));
-            }
         }
 
     }
@@ -193,6 +183,19 @@ class Bugsnag_Wordpress
         }
 
         $this->client->setUser($user);
+
+        if(!empty($this->apiKey)) {
+            // If handlers are not set, errors are still going to be reported
+            // to bugsnag, difference is execution will not stop.
+            //
+            // Can be useful to see inline errors and traces with xdebug too.
+            $set_error_and_exception_handlers = apply_filters('bugsnag_set_error_and_exception_handlers', true);
+            if ($set_error_and_exception_handlers === true) {
+                // Hook up automatic error handling
+                set_error_handler(array($this->client, "errorHandler"));
+                set_exception_handler(array($this->client, "exceptionHandler"));
+            }
+        }
     }
 
     // Unsafe: client can spoof address.


### PR DESCRIPTION
## Goal

As mention here https://github.com/bugsnag/bugsnag-wordpress/issues/41 this plugin prevents all error output. It removes PHP errors from being displayed on screen, even with WP_DEBUG turned on. 

The current WordPress filter "bugsnag_set_error_and_exception_handlers" is useless. The function is called on construct and could not be overwritten as planned.

## Design
Now the exception handler is set on WordPress init.

## Tests
manual

### Linked issues
Fixes #41 