### PR TITLE
Clarify the "Test Bugsnag" form action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 ### Enhancements
 
+* Clarify the "Test Bugsnag" form action [#46](https://github.com/bugsnag/bugsnag-wordpress/pull/46)
+
+## 1.4.0
+
+### Enhancements
+
 * Add WordPress version string to report payloads (device.runtimeVersions) [#39](https://github.com/bugsnag/bugsnag-wordpress/pull/39)
 
 ### Fixes

--- a/views/settings.php
+++ b/views/settings.php
@@ -10,7 +10,7 @@
     </p>
 
     <form method="post">
-        <?php if (empty($this->apiKey)) : ?>
+        <?php if (empty($this->apiKey)) { ?>
             <!-- API Key Prompt -->
             <div style="max-width: 560px; border: 1px solid #e6db55; padding: 0 10px 12px; background: #fffbcc">
                 <h3>Please configure your Bugsnag API Key to enable this plugin</h3>
@@ -27,7 +27,7 @@
 
                 <div style="clear: both"></div>
             </div>
-        <?php else: ?>
+        <?php } else { ?>
             <!-- Full Settings Form -->
             <table class="form-table">
                 <!-- API Key -->
@@ -75,7 +75,7 @@
             <div class="submit">
                 <input type="submit" class="button-primary" value="<?php _e('Save Changes') ?>" />
             </div>
-        <?php endif ?>
+        <?php } ?>
 
         <!-- Common form stuff -->
         <?php wp_nonce_field('update-options'); ?>
@@ -84,7 +84,7 @@
     </form>
 </div>
 
-<?php if (!empty($this->apiKey)): ?>
+<?php if (!empty($this->apiKey)) { ?>
     <div>
         <h2>Test your connection to Bugsnag</h2>
 
@@ -96,7 +96,7 @@
             <?php _e('Test Bugsnag Connection') ?>
         </button>
     </div>
-<?php endif ?>
+<?php } ?>
 
 <script type="text/javascript" >
 jQuery(document).ready(function($) {

--- a/views/settings.php
+++ b/views/settings.php
@@ -1,100 +1,105 @@
 <div class="wrap">
-  <h2>Bugsnag Settings</h2>
-  <p>
-    Bugsnag automatically detects errors &amp; crashes on your WordPress site, plugins &amp; themes.
-  </p>
-  <p>
-    Errors are sent to your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a> for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
-  </p>
+    <h2>Bugsnag Settings</h2>
 
-  <?php if (function_exists('is_plugin_active_for_network') && is_plugin_active_for_network($this->pluginBase)) { ?>
-  <form method='post'>
-  <?php } else { ?>
-  <form method="post">
-  <?php } ?>
-    <?php if (empty($this->apiKey)) { ?>
-
-    <!-- API Key Prompt -->
-    <div style="max-width: 560px; border: 1px solid #e6db55; padding: 0 10px 12px; background: #fffbcc">
-      <h3>Please configure your Bugsnag API Key to enable this plugin</h3>
-
-      <p>
-        Sign up for a <a href="https://app.bugsnag.com/user/new">Bugsnag Account</a> and create a project with type <i>WordPress</i>,<br>
-        you'll then be shown your API Key, which you should paste here:
-      </p>
-
-      <div style="margin-bottom: 10px;">
-        <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" style="width: 80%; float: left;" placeholder="Bugsnag API Key" autofocus="autofocus" />
-        <input type="submit" class="button-primary" value="<?php _e('Save') ?>" style="width: 15%; float: right;" />
-      </div>
-
-      <div style="clear: both"></div>
-    </div>
-
-    <?php } else { ?>
-
-    <!-- Full Settings Form -->
-    <table class="form-table">
-      <!-- API Key -->
-      <tr valign="top">
-        <th scope="row">
-          <label for="bugsnag_api_key">Bugsnag API Key</label>
-        </th>
-        <td>
-          <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" value="<?php echo $this->apiKey ?>" class="regular-text code" /><br>
-
-          <p class="description">
-            You can find your API Key on your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a>.
-          </p>
-        </td>
-      </tr>
-
-      <!--  $selected = (get_option('start_of_week') == $day_index) ? 'selected="selected"' : ''; -->
-      <tr valign="top">
-        <th>
-          <label for="bugsnag_notify_severities">Notify Bugsnag About</label>
-        </th>
-        <td>
-          <select name="bugsnag_notify_severities" id="bugsnag_notify_severities">
-            <?php $this->renderOption('Crashes &amp; errors', 'fatal,error', $this->notifySeverities); ?>
-            <?php $this->renderOption('Crashes, errors &amp; warnings', 'fatal,error,warning', $this->notifySeverities); ?>
-            <?php $this->renderOption('Crashes, errors, warnings &amp; info messages', 'fatal,error,warning,info', $this->notifySeverities); ?>
-          </select>
-        </td>
-      </tr>
-
-      <!-- Filter Fields -->
-      <tr valign="top">
-        <th>
-          <label for="bugsnag_filterfields">Bugsnag Field Filter</label>
-        </th>
-        <td>
-          <textarea id="bugsnag_filterfields" name="bugsnag_filterfields" class="regular-text filterfields"  style="width: 355px; height: 150px;"><?php echo $this->filterFields; ?></textarea>
-          <p class="description" style="max-width: 400px">
-            The information to remove from Bugsnag reports, one per line. Use this if you want to ensure you don't send sensitive data such as passwords, and credit card numbers to our servers.
-
-          </p>
-        </td>
-      </tr>
-    </table>
-
-    <p class="submit">
-      <input type="submit" class="button-primary" value="<?php _e('Save Changes') ?>" />
-      <input type="submit" id="bugsnag-test" class="button-secondary" value="<?php _e('Test Bugsnag') ?>" />
+    <p>
+        Bugsnag automatically detects errors &amp; crashes on your WordPress site, plugins &amp; themes.
     </p>
 
-    <?php } ?>
+    <p>
+        Errors are sent to your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a> for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
+    </p>
 
-    <!-- Common form stuff -->
-    <?php wp_nonce_field('update-options'); ?>
-    <input type="hidden" name="action" value="update" />
-    <input type="hidden" name="page_options" value="bugsnag_api_key,bugsnag_notify_severities,bugsnag_filterfields" />
-  </form>
+    <form method="post">
+        <?php if (empty($this->apiKey)) : ?>
+            <!-- API Key Prompt -->
+            <div style="max-width: 560px; border: 1px solid #e6db55; padding: 0 10px 12px; background: #fffbcc">
+                <h3>Please configure your Bugsnag API Key to enable this plugin</h3>
+
+                <p>
+                    Sign up for a <a href="https://app.bugsnag.com/user/new">Bugsnag Account</a> and create a project with type <i>WordPress</i>,<br>
+                    you'll then be shown your API Key, which you should paste here:
+                </p>
+
+                <div style="margin-bottom: 10px;">
+                    <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" style="width: 80%; float: left;" placeholder="Bugsnag API Key" autofocus="autofocus" />
+                    <input type="submit" class="button-primary" value="<?php _e('Save') ?>" style="width: 15%; float: right;" />
+                </div>
+
+                <div style="clear: both"></div>
+            </div>
+        <?php else: ?>
+            <!-- Full Settings Form -->
+            <table class="form-table">
+                <!-- API Key -->
+                <tr valign="top">
+                    <th scope="row">
+                        <label for="bugsnag_api_key">Bugsnag API Key</label>
+                    </th>
+                    <td>
+                        <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" value="<?php echo $this->apiKey ?>" class="regular-text code" /><br>
+
+                        <p class="description">
+                            You can find your API Key on your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a>.
+                        </p>
+                    </td>
+                </tr>
+
+                <tr valign="top">
+                    <th>
+                      <label for="bugsnag_notify_severities">Notify Bugsnag About</label>
+                    </th>
+                    <td>
+                        <select name="bugsnag_notify_severities" id="bugsnag_notify_severities">
+                            <?php $this->renderOption('Crashes &amp; errors', 'fatal,error', $this->notifySeverities); ?>
+                            <?php $this->renderOption('Crashes, errors &amp; warnings', 'fatal,error,warning', $this->notifySeverities); ?>
+                            <?php $this->renderOption('Crashes, errors, warnings &amp; info messages', 'fatal,error,warning,info', $this->notifySeverities); ?>
+                        </select>
+                    </td>
+                </tr>
+
+                <!-- Filter Fields -->
+                <tr valign="top">
+                    <th>
+                      <label for="bugsnag_filterfields">Bugsnag Field Filter</label>
+                    </th>
+                    <td>
+                        <textarea id="bugsnag_filterfields" name="bugsnag_filterfields" class="regular-text filterfields"  style="height: 150px;"><?php echo $this->filterFields; ?></textarea>
+                        <p class="description">
+                            The information to remove from Bugsnag reports, one per line.
+                            Use this if you want to ensure you don't send sensitive data such as passwords, and credit card numbers to our servers.
+                        </p>
+                    </td>
+                </tr>
+            </table>
+
+            <div class="submit">
+                <input type="submit" class="button-primary" value="<?php _e('Save Changes') ?>" />
+            </div>
+        <?php endif ?>
+
+        <!-- Common form stuff -->
+        <?php wp_nonce_field('update-options'); ?>
+        <input type="hidden" name="action" value="update" />
+        <input type="hidden" name="page_options" value="bugsnag_api_key,bugsnag_notify_severities,bugsnag_filterfields" />
+    </form>
 </div>
+
+<?php if (!empty($this->apiKey)): ?>
+    <div>
+        <h2>Test your connection to Bugsnag</h2>
+
+        <p>Use this button to send a test event that can be viewed in <a href="https://app.bugsnag.com">your Bugsnag Dashboard</a>.</p>
+
+        <p>Note - any <a href="https://docs.bugsnag.com/platforms/php/wordpress/configuration-options/">configuration options</a> applied in code will not be applied to this test event.</p>
+
+        <button id="bugsnag-test" class="button-secondary">
+            <?php _e('Test Bugsnag Connection') ?>
+        </button>
+    </div>
+<?php endif ?>
 
 <script type="text/javascript" >
 jQuery(document).ready(function($) {
-
     $('#bugsnag-test').click(function (e) {
         e.stopPropagation();
         e.preventDefault();
@@ -110,7 +115,6 @@ jQuery(document).ready(function($) {
         $.post(ajaxurl, data, function(response) {
             alert('Sent notification. Visit https://app.bugsnag.com/ to see it in your dashboard');
         });
-
     });
 });
 </script>


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

The current wording of the "Test Bugsnag" action is somewhat unclear

The intention is to test that we can communicate with Bugsnag using the given API Key, not to be a comprehensive test of the Bugsnag client, but that isn't currently made clear

This PR separates the test action from the main form and adds some clarifying text to make clear what the form is intended for

**Before**
<img width="1117" alt="before" src="https://user-images.githubusercontent.com/282732/80088056-e93b9f80-8553-11ea-8cf8-7ac4858aeef9.png">

**After**
![Screenshot 2020-04-23 at 16 50 21](https://user-images.githubusercontent.com/282732/80120208-90373000-8582-11ea-9f98-8884b4f8f6dc.png)

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->

## Changeset

<!-- What structures or properties or functions were:

### Added

### Removed

### Changed

- The "Test Bugsnag" button is now in a separate section underneath the settings form. It will not be shown when an API key hasn't been entered

-->

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

This was tested manually be ensuring the test button still notifies Bugsnag with a test message

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

The current wording reads a bit awkwardly to me but I'm struggling to come up with anything better — any suggestions would be greatly appreciated!

### Linked issues

Related to #43 
StyleCI has been fixed in #45 so it will fail in this branch until that PR is merged

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

The changeset is much easier to review by ignoring whitespace changes!

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
