### PR TITLE
Improve error message when methods are called with no api key set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Enhancements
 
 * Clarify the "Test Bugsnag" form action [#46](https://github.com/bugsnag/bugsnag-wordpress/pull/46)
+* Improve error message when methods are called with no api key set [#47](https://github.com/bugsnag/bugsnag-wordpress/pull/47)
 
 ## 1.4.0
 

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -313,7 +313,9 @@ class Bugsnag_Wordpress
         // because the client needs an API key on construction and we need to fail
         // loudly so the user knows their site isn't setup correctly.
         if (empty($this->apiKey)) {
-            throw new BadMethodCallException('No Bugsnag API Key set');
+            throw new BadMethodCallException(
+                'No Bugsnag API Key set. Please enter your API Key on the Bugsnag Settings page.'
+            );
         }
 
         if (method_exists($this->client, $method)) {

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -308,6 +308,14 @@ class Bugsnag_Wordpress
      */
     public function __call($method, $arguments)
     {
+        // If we don't have an API key here then the plugin has not been setup, but
+        // methods are already being called. We can't forward these calls through
+        // because the client needs an API key on construction and we need to fail
+        // loudly so the user knows their site isn't setup correctly.
+        if (empty($this->apiKey)) {
+            throw new BadMethodCallException('No Bugsnag API Key set');
+        }
+
         if (method_exists($this->client, $method)) {
             return call_user_func_array(array($this->client, $method), $arguments);
         }


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

Currently if you call a method which should be forwarded on to the Bugnsag Client before you've provided an API Key, we error with the message:

> Method foo does not exist on Bugsnag_Wordpress or Bugsnag_Client

This isn't true — the method might exist — but as we have no API Key we don't construct a Client so we test `method_exists` on `null`, which always returns false

This PR adds a check for an API Key in `__call`, so we can provide a better error message. We need to fail loudly in this case because if a user is calling configuration methods then presumably they expect Bugsnag to be working when actually it's not setup at all

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->

## Changeset

<!-- What structures or properties or functions were:

### Added

### Removed

### Changed

- `__call` now checks for an API Key existing before trying to forward on the call to the Bugsnag Client

-->

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

This was tested manually by adding a method call to `functions.php` (e.g. `$bugsnagWordpress->setDebug(true);`) and then removing the API Key from the Bugsnag settings page

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

Related to #42 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
