### PR TITLE
Update Release Stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Use `wp_get_environment_type` to set the release stage, when it's available [bhubbard](https://github.com/bhubbard) [#53](https://github.com/bugsnag/bugsnag-wordpress/pull/53)
+
 ## 1.5.0 (2020-04-29)
 
 ### Enhancements

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -162,16 +162,17 @@ class Bugsnag_Wordpress
 
     /**
      * Set Release Stage.
+     *
      * @return $release_stage_filtered Release Stage Filtered.
      */
     private function releaseStage()
     {
-        if( function_exists( 'wp_get_environment_type' ) ) {
-          $release_stage =  wp_get_environment_type(); // Defaults to production when not set.
+        if (function_exists('wp_get_environment_type')) {
+            $release_stage = wp_get_environment_type(); // Defaults to production when not set.
         } else {
-          $release_stage = defined( 'WP_ENV' ) ? WP_ENV : 'production';
+            $release_stage = defined('WP_ENV') ? WP_ENV : 'production';
         }
-        $release_stage_filtered = apply_filters( 'bugsnag_release_stage', $release_stage );
+        $release_stage_filtered = apply_filters('bugsnag_release_stage', $release_stage);
 
         return $release_stage_filtered;
     }

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -160,10 +160,18 @@ class Bugsnag_Wordpress
         return array_map('trim', explode("\n", $filter_fields));
     }
 
+    /**
+     * Set Release Stage.
+     * @return $release_stage_filtered Release Stage Filtered.
+     */
     private function releaseStage()
     {
-        $release_stage = defined('WP_ENV') ? WP_ENV : 'production';
-        $release_stage_filtered = apply_filters('bugsnag_release_stage', $release_stage);
+        if( function_exists( 'wp_get_environment_type' ) ) {
+          $release_stage =  wp_get_environment_type(); // Defaults to production when not set.
+        } else {
+          $release_stage = defined( 'WP_ENV' ) ? WP_ENV : 'production';
+        }
+        $release_stage_filtered = apply_filters( 'bugsnag_release_stage', $release_stage );
 
         return $release_stage_filtered;
     }


### PR DESCRIPTION
Add support for `wp_get_enviornment_type()` which was introduced in WP 5.5