### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Changelog
 =========
 
-## TBD
+## v1.6.0 (2020-11-17)
 
 ### Enhancements
 
 * Use `wp_get_environment_type` to set the release stage, when it's available [bhubbard](https://github.com/bhubbard) [#53](https://github.com/bugsnag/bugsnag-wordpress/pull/53)
+* Update bundled bugsnag-php version to v2.10.1
 
 ## 1.5.0 (2020-04-29)
 

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -3,7 +3,7 @@
 Plugin Name: Bugsnag Error Monitoring
 Plugin URI: https://bugsnag.com
 Description: Bugsnag monitors for errors and crashes on your wordpress site, sends them to your bugsnag.com dashboard, and notifies you by email of each error.
-Version: 1.5.0
+Version: 1.6.0
 Author: Bugsnag Inc.
 Author URI: https://bugsnag.com
 License: GPLv2 or later
@@ -17,7 +17,7 @@ class Bugsnag_Wordpress
 
     private static $NOTIFIER = array(
         'name' => 'Bugsnag Wordpress (Official)',
-        'version' => '1.5.0',
+        'version' => '1.6.0',
         'url' => 'https://bugsnag.com/notifiers/wordpress',
     );
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bugsnag/bugsnag-wordpress",
     "type": "wordpress-plugin",
     "require": {
-        "bugsnag/bugsnag": "^2.10",
+        "bugsnag/bugsnag": "^2.10.1",
         "composer/installers": "^1.0"
     },
     "license": "MIT",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
 Tested up to: 5.4
-Stable tag: 1.5.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 
 Bugsnag is a WordPress plugin that automatically detects errors & crashes on your WordPress site, and notifies you by email, chat or issues system

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
-Tested up to: 5.4
+Tested up to: 5.5.3
 Stable tag: 1.6.0
 License: GPLv2 or later
 

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ To manually install Bugsnag:
 
 == Changelog ==
 
+= 1.6.0 =
+* Add support for setting the release stage using the new "wp_get_environment_type" function
+* Update bugsnag-php to v2.10.1
+
 = 1.5.0 =
 * Clarify the "Test Bugsnag" form action
 * Improve error message when methods are called with no api key set


### PR DESCRIPTION
## v1.6.0 (2020-11-17)

### Enhancements

* Use `wp_get_environment_type` to set the release stage, when it's available [bhubbard](https://github.com/bhubbard) [#53](https://github.com/bugsnag/bugsnag-wordpress/pull/53)
* Update bundled bugsnag-php version to v2.10.1