### PR TITLE
License-audit: Add license-audit workflow to github actions

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -1,0 +1,31 @@
+name: Audit bugsnag-wordpress dependency licenses
+
+on: [push, pull_request]
+
+jobs:
+  license-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.0'
+        coverage: none
+        extensions: intl, mbstring
+
+    - name: Fetch decisions.yml
+      run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml
+
+    - name: Install composer dependencies
+      run: composer install --no-dev
+
+    - name: Run License Finder
+      # for some reason license finder doesn't run without a login shell (-l)
+      run: >
+        docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
+          cd /scan &&
+          license_finder --decisions-file decisions.yml --composer-check-require-only=true --enabled-package-managers=composer
+        "

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 vendor
 composer.lock
 svn
+decisions.yml


### PR DESCRIPTION
## Goal

Adds a workflow to github actions that verifies the licenses of all required deps are suitable for the notifier.