### PR TITLE
fix: docs url in test notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## TBD (TBD)
+
+* Fix broken url in notifier configuration & add docs link to test notification [#60](https://github.com/bugsnag/bugsnag-wordpress/pull/60)
+
 ## v1.6.1 (2021-09-21)
 
 * Bump "tested up to" WordPress version

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -289,7 +289,7 @@ class Bugsnag_Wordpress
             'BugsnagTest',
             'Testing bugsnag',
             array('notifier' => self::$NOTIFIER,
-                  'docs' => array('url' => "https://docs.bugsnag.com/platforms/php/wordpress/"))
+                'docs' => array('url' => "https://docs.bugsnag.com/platforms/php/wordpress/"))
         );
 
         die();

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -288,8 +288,10 @@ class Bugsnag_Wordpress
         $this->client->notifyError(
             'BugsnagTest',
             'Testing bugsnag',
-            array('notifier' => self::$NOTIFIER,
-                'docs' => array('url' => "https://docs.bugsnag.com/platforms/php/wordpress/"))
+            array(
+                'notifier' => self::$NOTIFIER,
+                'docs' => array('url' => 'https://docs.bugsnag.com/platforms/php/wordpress/'),
+            )
         );
 
         die();

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -288,7 +288,8 @@ class Bugsnag_Wordpress
         $this->client->notifyError(
             'BugsnagTest',
             'Testing bugsnag',
-            array('notifier' => self::$NOTIFIER)
+            array('notifier' => self::$NOTIFIER,
+                  'docs' => array('url' => "https://docs.bugsnag.com/platforms/php/wordpress/"))
         );
 
         die();

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -18,7 +18,7 @@ class Bugsnag_Wordpress
     private static $NOTIFIER = array(
         'name' => 'Bugsnag Wordpress (Official)',
         'version' => '1.6.1',
-        'docs' => 'https://docs.bugsnag.com/platforms/php/wordpress',
+        'url' => 'https://github.com/bugsnag/bugsnag-wordpress',
     );
 
     private $client;

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -18,7 +18,7 @@ class Bugsnag_Wordpress
     private static $NOTIFIER = array(
         'name' => 'Bugsnag Wordpress (Official)',
         'version' => '1.6.1',
-        'url' => 'https://bugsnag.com/notifiers/wordpress',
+        'docs' => 'https://docs.bugsnag.com/platforms/php/wordpress',
     );
 
     private $client;

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,9 @@ To manually install Bugsnag:
 
 == Changelog ==
 
+= TBD
+* Fix broken url in notifier configuration & add docs link to test notification.
+
 = 1.6.1
 * Bump "tested up to" WordPress version
 


### PR DESCRIPTION
## Goal

Docs URL currently points to an old marketing page, updated to point to the WordPress documentation to help new users get started.