### PR TITLE
Release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-## TBD (TBD)
+## v1.6.2 (2023-01-26)
 
 * Fix broken url in notifier configuration & add docs link to test notification [#60](https://github.com/bugsnag/bugsnag-wordpress/pull/60)
+* Bump "tested up to" WordPress version
 
 ## v1.6.1 (2021-09-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## TBD (TBD)
+
+* Fix broken url in notifier configuration & add docs link to test notification [#60](https://github.com/bugsnag/bugsnag-wordpress/pull/60)
+
 ## v1.6.1 (2021-09-21)
 
 * Bump "tested up to" WordPress version

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -18,7 +18,7 @@ class Bugsnag_Wordpress
     private static $NOTIFIER = array(
         'name' => 'Bugsnag Wordpress (Official)',
         'version' => '1.6.1',
-        'url' => 'https://bugsnag.com/notifiers/wordpress',
+        'url' => 'https://github.com/bugsnag/bugsnag-wordpress',
     );
 
     private $client;
@@ -288,7 +288,10 @@ class Bugsnag_Wordpress
         $this->client->notifyError(
             'BugsnagTest',
             'Testing bugsnag',
-            array('notifier' => self::$NOTIFIER)
+            array(
+                'notifier' => self::$NOTIFIER,
+                'docs' => array('url' => 'https://docs.bugsnag.com/platforms/php/wordpress/'),
+            )
         );
 
         die();

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
             "name": "James Smith",
             "email": "james@loopj.com"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
+    }
 }

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     environment:
       - MYSQL_DATABASE=wordpress
       - MYSQL_USER=wp_admin

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ To manually install Bugsnag:
 
 == Changelog ==
 
-= TBD
+= 1.6.2 =
 * Fix broken url in notifier configuration & add docs link to test notification.
 * Bump "tested up to" WordPress version
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
-Tested up to: 5.8.1
+Tested up to: 6.1.1
 Stable tag: 1.6.1
 License: GPLv2 or later
 
@@ -40,6 +40,7 @@ To manually install Bugsnag:
 
 = TBD
 * Fix broken url in notifier configuration & add docs link to test notification.
+* Bump "tested up to" WordPress version
 
 = 1.6.1
 * Bump "tested up to" WordPress version

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,9 @@ To manually install Bugsnag:
 
 == Changelog ==
 
+= TBD
+* Fix broken url in notifier configuration & add docs link to test notification.
+
 = 1.6.1
 * Bump "tested up to" WordPress version
 

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ To manually install Bugsnag:
 * Fix broken url in notifier configuration & add docs link to test notification.
 * Bump "tested up to" WordPress version
 
-= 1.6.1
+= 1.6.1 =
 * Bump "tested up to" WordPress version
 
 = 1.6.0 =


### PR DESCRIPTION
* Fix broken url in notifier configuration & add docs link to test notification [#60](https://github.com/bugsnag/bugsnag-wordpress/pull/60)
* Bump "tested up to" WordPress version