### PR TITLE
docs: update plugin name and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v1.6.5 (2025-09-30)
+
+* Update plugin metadata [#66](https://github.com/bugsnag/bugsnag-wordpress/pull/67)
+
 ## v1.6.4 (2025-09-15)
 
 * Patch CVE-2025-58806 [#66](https://github.com/bugsnag/bugsnag-wordpress/pull/66)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
-Bugsnag Notifier for WordPress
-==============================
+<div align="center">
+  <a href="https://www.bugsnag.com/platforms/php/wordpress/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.smartbear.com/m/3dab7e6cf880aa2b/original/BugSnag-Repository-Header-Dark.svg">
+      <img alt="SmartBear BugSnag logo" src="https://assets.smartbear.com/m/3945e02cdc983893/original/BugSnag-Repository-Header-Light.svg">
+    </picture>
+  </a>
+  <h1>Error monitoring plugin for WordPress</h1>
+</div>
 
-The Bugsnag Notifier for WordPress gives you instant notification of errors 
-in your WordPress sites.
+[![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/php/wordpress/)
 
-[Bugsnag](https://www.bugsnag.com/) captures errors in real-time from your web, 
-mobile and desktop applications, helping you to understand and resolve them 
-as fast as possible. Create a free account to start 
-capturing errors from your applications. Learn more about [error monitoring and error reporting](https://www.bugsnag.com/) with Bugsnag.
+The BugSnag Error Monitoring plugin for WordPress gives you instant notification of errors in your WordPress sites.
 
-The Bugsnag Notifier for WordPress supports WordPress 2.0+, PHP 5.2+ and
-requires the cURL extension to be available in PHP.
+[BugSnag](https://www.bugsnag.com/) captures errors in real-time from your web, mobile and desktop applications, helping you to understand and resolve them as fast as possible. Create a free account to start capturing errors from your applications. Learn more about [error monitoring and error reporting](https://www.bugsnag.com/) with BugSnag.
 
-You can always read about the plugin or download it from the
-[WordPress Plugin Directory](http://wordpress.org/plugins/bugsnag/).
+This plugin supports WordPress 2.0+, PHP 5.2+ and requires the cURL extension to be available in PHP.
+
+You can read about the plugin or download it from the [WordPress Plugin Directory](http://wordpress.org/plugins/bugsnag/).
 
 
-How to Install
---------------
+## How to Install
 
 1.  Download the latest [bugsnag.zip](https://github.com/bugsnag/bugsnag-wordpress/releases/latest).
 
@@ -33,39 +35,27 @@ How to Install
     [Bugsnag Dashboard](https://bugsnag.com).
 
 
-Building from Source
---------------------
+## Building from Source
 
-If you would like to build a new zip file of the plugin from source, you can
-run our build script using [Thor](http://whatisthor.com/). You'll need both
-`ruby` and the `thor` gem installed (`gem install thor`). Then you can
-generate a new zip by running:
+If you would like to build a new zip file of the plugin from source, you can run our build script using [Thor](http://whatisthor.com/). You'll need both `ruby` and the `thor` gem installed (`gem install thor`). Then you can generate a new zip by running:
 
 ```shell
 thor wordpress:zip bugsnag-wordpress.zip
 ```
 
+## Support
 
-Reporting Bugs or Feature Requests
-----------------------------------
+* [Read the integration guide](https://docs.bugsnag.com/platforms/php/wordpress)
+* [Search open and closed issues](https://github.com/bugsnag/bugsnag-wordpress/issues?utf8=✓&q=is%3Aissue) for similar problems
+* [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-wordpress/issues/new)
 
-Please report any bugs or feature requests on the github issues page for this
-project here:
-
-<https://github.com/bugsnag/bugsnag-wordpress/issues>
-
-
-Contributing
-------------
+## Contributing
 
 -   [Fork](https://help.github.com/articles/fork-a-repo) the [notifier on github](https://github.com/bugsnag/bugsnag-wordpress)
 -   Commit and push until you are happy with your contribution
 -   [Make a pull request](https://help.github.com/articles/using-pull-requests)
 -   Thanks!
 
+## License
 
-License
--------
-
-The Bugsnag WordPress notifier is free software released under the WordPress-friendly GPLv2 License. 
-See [LICENSE.txt](https://github.com/bugsnag/bugsnag-wordpress/blob/master/LICENSE.txt) for details.
+The BugSnag WordPress plugin is free software released under the WordPress-friendly GPLv2 License. See [LICENSE.txt](https://github.com/bugsnag/bugsnag-wordpress/blob/master/LICENSE.txt) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,4 @@
 
 ## Reporting a Vulnerability
 
-If you find a vulnerability in this SDK, please report it to our [Support Team](mailto:support@bugsnag.com) for review.
+If you find a vulnerability in this SDK, please report it to our [Support Team](mailto:security@smartbear.com) for review.

--- a/bugsnag.php
+++ b/bugsnag.php
@@ -1,10 +1,10 @@
 <?php
 /*
-Plugin Name: Bugsnag Error Monitoring
+Plugin Name: BugSnag Error Monitoring plugin
 Plugin URI: https://bugsnag.com
-Description: Bugsnag monitors for errors and crashes on your wordpress site, sends them to your bugsnag.com dashboard, and notifies you by email of each error.
+Description: Automatically detects errors & crashes on your WordPress site using BugSnag to notify you by email, chat or issues system.
 Version: 1.6.4
-Author: Bugsnag Inc.
+Author: BugSnag
 Author URI: https://bugsnag.com
 License: GPLv2 or later
 */

--- a/example/README.md
+++ b/example/README.md
@@ -1,8 +1,8 @@
-# Bugsnag WordPress demo
+# BugSnag WordPress demo
 
-This docker application provides a worked example of how to install Bugsnag into a wordpress installation.
+This docker application provides a worked example of how to install BugSnag into a wordpress installation.
 
-Try this out with [your own Bugsnag account](https://app.bugsnag.com/user/new)!
+Try this out with [your own BugSnag account](https://app.bugsnag.com/user/new)!
 
 ## Starting the WordPress app
 
@@ -21,33 +21,32 @@ docker-compose up -d
 
 Once the application is running navigate to `http://localhost:8080` and follow the on-screen instructions to finalize the settings of your local wordpress application.
 
-## Installing Bugsnag
+## Installing BugSnag
 
-First Bugsnag needs to be added to your WordPress app. This can be accomplished in one of two ways:
+First BugSnag needs to be added to your WordPress app. This can be accomplished in one of two ways:
 
 ### Using the plugin installer
 
 - Inside the admin dashboard of your WordPress app, navigate to the `Plugins` section.
 - From there, select the `Add New` button next to the `Plugins` title.
 - Search for `Bugsnag` in the `Search plugins...` search field in the top right.
-- Select `Install Now` on the plugin titled `WordPress Error Monitoring by Bugsnag` By `Bugsnag Inc.`
+- Select `Install Now` on the plugin titled `BugSnag Error Monitoring plugin` By `BugSnag`
 
 ### Manual install
 
-- Visit the [WordPress plugin index](https://wordpress.org/plugins/bugsnag/) and search for `Bugsnag`.
-- Download the Bugsnag ZIP file and unzip it.
+- Visit the [WordPress plugin index](https://wordpress.org/plugins/bugsnag/) and search for `bugsnag`.
+- Download the BugSnag ZIP file and unzip it.
 - Move the `bugsnag` folder from the unzipped file to the `app/wp-content/plugins` folder.
 
-## Activating and testing Bugsnag
+## Activating and testing BugSnag
 
-On your WordPress admin dashboard visit the `Plugins` section. In the list of plugins, find `Bugsnag Error Monitoring` and press `activate`.
-Once activated, press `settings` and enter your Bugsnag API key in the resulting screen.
+On your WordPress admin dashboard visit the `Plugins` section. In the list of plugins, find `BugSnag Error Monitoring plugin` and press `activate`.
+Once activated, press `settings` and enter your BugSnag API key in the resulting screen.
 
-You can test your installation by sending an example notification from your WordPress app to Bugsnag using the `Test Bugsnag` button on the settings page.
+You can test your installation by sending an example notification from your WordPress app to BugSnag using the `Test BugSnag` button on the settings page.
 
-
-For more information, see our documentation:
-https://docs.bugsnag.com/platforms/php/wordpress/
+For more information, see our documentation: https://docs.bugsnag.com/platforms/php/wordpress/
 
 ### Notes on docker-volumes
+
 The docker-compose file in this example exposes the `/var/www/html/` folder of the WordPress app within the `app` folder in this directory. This allows you to easily modify various aspects of your WordPress installation and see the result instantly on your local machine.

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WordPress Error Monitoring by Bugsnag ===
+=== BugSnag Error Monitoring plugin ===
 Contributors: loopj
 Tags: bugsnag, error, monitoring, exception, logging
 Requires at least: 2.0
@@ -6,21 +6,20 @@ Tested up to: 6.8.2
 Stable tag: 1.6.4
 License: GPLv2 or later
 
-Bugsnag is a WordPress plugin that automatically detects errors & crashes on your WordPress site, and notifies you by email, chat or issues system
-
+Automatically detects errors & crashes on your WordPress site using BugSnag to notify you by email, chat or issues system.
 
 == Description ==
 
-Bugsnag is a WordPress plugin that automatically detects errors & crashes on your WordPress site, and notifies you by email, chat or ticket system.
+Automatically detects errors & crashes on your WordPress site using BugSnag to notify you by email, chat or issues system.
 
-All websites crash from time to time, including WordPress sites! The *WordPress Error Monitoring* plugin by Bugsnag automatically detects crashes, exceptions and other errors in your WordPress PHP code as well as any errors in plugins you are using.
+All websites crash from time to time, including WordPress sites! Th BugSnag Error Reporting plugin automatically detects crashes, exceptions and other errors in your WordPress PHP code as well as any errors in plugins you are using.
 
-Errors are sent to your [Bugsnag Dashboard](https://bugsnag.com) for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
+Errors are sent to your [BugSnag Dashboard](https://bugsnag.com) for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
 
 
 == Installation ==
 
-Bugsnag is available through the [WordPress Plugins Directory](http://wordpress.org/plugins/), so you can download and install automatically from the Plugins menu on your WordPress admin page.
+BugSnag is available through the [WordPress Plugins Directory](http://wordpress.org/plugins/), so you can download and install automatically from the Plugins menu on your WordPress admin page.
 
 To manually install Bugsnag:
 
@@ -32,11 +31,14 @@ To manually install Bugsnag:
 
 == Screenshots ==
 
-1. Bugsnag dashboard list of errors
-2. Bugsnag dashboard error details
+1. BugSnag dashboard list of errors
+2. BugSnag dashboard error details
 
 
 == Changelog ==
+
+= 1.6.5 =
+* Update plugin metadata
 
 = 1.6.4 =
 * Patch CVE-2025-58806

--- a/views/settings.php
+++ b/views/settings.php
@@ -1,22 +1,22 @@
 <div class="wrap">
-    <h2>Bugsnag Settings</h2>
+    <h2>BugSnag Settings</h2>
 
     <p>
-        Bugsnag automatically detects errors &amp; crashes on your WordPress site, plugins &amp; themes.
+        BugSnag automatically detects errors &amp; crashes on your WordPress site, plugins &amp; themes.
     </p>
 
     <p>
-        Errors are sent to your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a> for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
+        Errors are sent to your <a href="https://app.bugsnag.com">BugSnag Dashboard</a> for you to view and debug, and we'll also notify you by email, chat, sms or create a ticket in your issue tracking system if you use one. We'll also show you exactly how many times each error occurred, and how many users were impacted by each crash.
     </p>
 
     <form method="post">
         <?php if (empty($this->apiKey)) { ?>
             <!-- API Key Prompt -->
             <div style="max-width: 560px; border: 1px solid #e6db55; padding: 0 10px 12px; background: #fffbcc">
-                <h3>Please configure your Bugsnag API Key to enable this plugin</h3>
+                <h3>Please configure your BugSnag API Key to enable this plugin</h3>
 
                 <p>
-                    Sign up for a <a href="https://app.bugsnag.com/user/new">Bugsnag Account</a> and create a project with type <i>WordPress</i>,<br>
+                    Sign up for a <a href="https://app.bugsnag.com/user/new">BugSnag Account</a> and create a project with type <i>WordPress</i>,<br>
                     you'll then be shown your API Key, which you should paste here:
                 </p>
 
@@ -33,20 +33,20 @@
                 <!-- API Key -->
                 <tr valign="top">
                     <th scope="row">
-                        <label for="bugsnag_api_key">Bugsnag API Key</label>
+                        <label for="bugsnag_api_key">BugSnag API Key</label>
                     </th>
                     <td>
                         <input type="text" id="bugsnag_api_key" name="bugsnag_api_key" value="<?php echo $this->apiKey ?>" class="regular-text code" /><br>
 
                         <p class="description">
-                            You can find your API Key on your <a href="https://app.bugsnag.com">Bugsnag Dashboard</a>.
+                            You can find your API Key on your <a href="https://app.bugsnag.com">BugSnag Dashboard</a>.
                         </p>
                     </td>
                 </tr>
 
                 <tr valign="top">
                     <th>
-                      <label for="bugsnag_notify_severities">Notify Bugsnag About</label>
+                      <label for="bugsnag_notify_severities">Notify BugSnag About</label>
                     </th>
                     <td>
                         <select name="bugsnag_notify_severities" id="bugsnag_notify_severities">
@@ -60,12 +60,12 @@
                 <!-- Filter Fields -->
                 <tr valign="top">
                     <th>
-                      <label for="bugsnag_filterfields">Bugsnag Field Filter</label>
+                      <label for="bugsnag_filterfields">BugSnag Field Filter</label>
                     </th>
                     <td>
                         <textarea id="bugsnag_filterfields" name="bugsnag_filterfields" class="regular-text filterfields"  style="height: 150px;"><?php echo $this->filterFields; ?></textarea>
                         <p class="description">
-                            The information to remove from Bugsnag reports, one per line.
+                            The information to remove from BugSnag reports, one per line.
                             Use this if you want to ensure you don't send sensitive data such as passwords, and credit card numbers to our servers.
                         </p>
                     </td>
@@ -86,14 +86,14 @@
 
 <?php if (!empty($this->apiKey)) { ?>
     <div>
-        <h2>Test your connection to Bugsnag</h2>
+        <h2>Test your connection to BugSnag</h2>
 
-        <p>Use this button to send a test event that can be viewed in <a href="https://app.bugsnag.com">your Bugsnag Dashboard</a>.</p>
+        <p>Use this button to send a test event that can be viewed in <a href="https://app.bugsnag.com">your BugSnag Dashboard</a>.</p>
 
         <p>Note - any <a href="https://docs.bugsnag.com/platforms/php/wordpress/configuration-options/">configuration options</a> applied in code will not be applied to this test event.</p>
 
         <button id="bugsnag-test" class="button-secondary">
-            <?php _e('Test Bugsnag Connection') ?>
+            <?php _e('Test BugSnag Connection') ?>
         </button>
     </div>
 <?php } ?>


### PR DESCRIPTION
## Goal

Apply latest branding changes and ensure plugin name is not violating [naming](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#17-plugins-must-respect-trademarks-copyrights-and-project-names).