### PR TITLE
Feature/session tracking

### DIFF
--- a/bugsnag.php
+++ b/bugsnag.php
@@ -30,12 +30,16 @@ class Bugsnag_Wordpress
     private $apiKey;
     private $notifySeverities;
     private $filterFields;
+    private $trackSessions;
     private $pluginBase;
 
     public function __construct()
     {
         // Activate bugsnag error monitoring as soon as possible
         $this->activateBugsnag();
+
+        // Start session tracking if enabled as early as possible
+        $this->maybeTrackSession();
 
         $this->pluginBase = 'bugsnag/bugsnag.php';
 
@@ -66,11 +70,13 @@ class Bugsnag_Wordpress
             $this->apiKey = get_option('bugsnag_api_key');
             $this->notifySeverities = get_option('bugsnag_notify_severities');
             $this->filterFields = get_option('bugsnag_filterfields');
+            $this->trackSessions = get_option('bugsnag_track_sessions');
         } else {
             // Multisite
             $this->apiKey = get_site_option('bugsnag_api_key');
             $this->notifySeverities = get_site_option('bugsnag_notify_severities');
             $this->filterFields = get_site_option('bugsnag_filterfields');
+            $this->trackSessions = get_site_option('bugsnag_track_sessions');
         }
 
         $this->constructBugsnag();
@@ -181,6 +187,15 @@ class Bugsnag_Wordpress
         return $release_stage_filtered;
     }
 
+    private function maybeTrackSession()
+    {
+        if(!checked($this->trackSessions, true, false)) {
+            return;
+        }
+
+        $this->client->startSession();
+    }
+
     // Action hooks
     public function registerUser()
     {
@@ -253,12 +268,14 @@ class Bugsnag_Wordpress
         update_site_option('bugsnag_api_key', isset($_POST['bugsnag_api_key']) ? $_POST['bugsnag_api_key'] : '');
         update_site_option('bugsnag_notify_severities', isset($_POST['bugsnag_notify_severities']) ? $_POST['bugsnag_notify_severities'] : '');
         update_site_option('bugsnag_filterfields', isset($_POST['bugsnag_filterfields']) ? $_POST['bugsnag_filterfields'] : '');
+        update_site_option('bugsnag_track_sessions', isset($_POST['bugsnag_track_sessions']) ? $_POST['bugsnag_track_sessions'] : '');
         update_site_option('bugsnag_network', true);
 
         // Update variables
         $this->apiKey = get_site_option('bugsnag_api_key');
         $this->notifySeverities = get_site_option('bugsnag_notify_severities');
         $this->filterFields = get_site_option('bugsnag_filterfields');
+        $this->trackSessions = get_site_option('bugsnag_track_sessions');
 
         echo '<div class="updated"><p>Settings saved.</p></div>';
     }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bugsnag/bugsnag-wordpress",
     "type": "wordpress-plugin",
     "require": {
-        "bugsnag/bugsnag": "^2.10.2",
+        "bugsnag/bugsnag": "^3.30.0",
         "composer/installers": "^1.0"
     },
     "license": "MIT",

--- a/views/settings.php
+++ b/views/settings.php
@@ -70,6 +70,20 @@
                         </p>
                     </td>
                 </tr>
+
+                <!-- Track Sessions -->
+                <tr valign="top">
+                    <th>
+                        <label for="bugsnag_track_sessions">Track Sessions</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" id="bugsnag_track_sessions" name="bugsnag_track_sessions" value="1" <?php checked($this->trackSessions, true); ?> />
+                        <p class="description">
+                            Enable automatic session tracking to monitor stability metrics in your BugSnag dashboard.
+                            <br> Read more about <a href="https://docs.bugsnag.com/product/stability/" target="_blank">stability metrics</a>.
+                        </p>
+                    </td>
+                </tr>
             </table>
 
             <div class="submit">


### PR DESCRIPTION
## Goal

To implement Session tracking for the stability score in Bugsnag.

## Design

It builds on top on my other pull request for V3 of the PHP SDK. 
Its optional to use session tracking due to the implemented setting. 

## Changeset

I have added a checkbox to the settings page to allow session tracking to be toggled on/off.
I have implemented the session tracking functionality as early as possible with its own method `maybeTrackSession`.

## Testing

I have manually tested in a test environment against a test project in bugsnag.